### PR TITLE
Update Youtube thumb url

### DIFF
--- a/lib/embedjs.js
+++ b/lib/embedjs.js
@@ -35,7 +35,7 @@ SteemEmbed.get = function (url, options) {
       'type': 'video',
       'url': url,
       'provider_name': 'YouTube',
-      'thumbnail': 'https://i.ytimg.com/vi/' + youtubeId + '/hqdefault.jpg',
+      'thumbnail': 'https://i.ytimg.com/vi_webp/' + youtubeId + '/sddefault.webp',
       'id': youtubeId,
       'embed': this.youtube(url, youtubeId, options)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embedjs",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Extract embed information for all the media links in your texts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Trying a new format url for Youtube which seem to have better quality
Before: https://i.ytimg.com/vi/V-pPOEAXFO4/hqdefault.jpg
After: https://i.ytimg.com/vi_webp/V-pPOEAXFO4/sddefault.webp