### PR TITLE
Switch back to hqdefault.jpg for youtube

### DIFF
--- a/lib/embedjs.js
+++ b/lib/embedjs.js
@@ -35,7 +35,7 @@ SteemEmbed.get = function (url, options) {
       'type': 'video',
       'url': url,
       'provider_name': 'YouTube',
-      'thumbnail': 'https://i.ytimg.com/vi_webp/' + youtubeId + '/sddefault.webp',
+      'thumbnail': 'https://i.ytimg.com/vi/' + youtubeId + '/hqdefault.jpg',
       'id': youtubeId,
       'embed': this.youtube(url, youtubeId, options)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embedjs",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Extract embed information for all the media links in your texts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It seem that with the new url for some video the preview is not avaible, while with the old url it seem to be working but has lower quality.
https://trello.com/c/PEldRov7/222-youtube-preview-fail-to-load