### PR TITLE
Get Youtube thumbnails in 16:9 ratio.

### DIFF
--- a/lib/embedjs.js
+++ b/lib/embedjs.js
@@ -41,7 +41,7 @@ SteemEmbed.get = function (url, options) {
       'type': 'video',
       'url': url,
       'provider_name': 'YouTube',
-      'thumbnail': 'https://i.ytimg.com/vi/' + youtubeId + '/hqdefault.jpg',
+      'thumbnail': 'https://img.youtube.com/vi/' + youtubeId + '/mqdefault.jpg',
       'id': youtubeId,
       'embed': this.youtube(url, youtubeId, options)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ expect(embeds).toEqual(
     type: 'video',
     url: 'https://youtu.be/DAYNwC-aMgQ?t=2m8s',
     provider_name: 'YouTube',
-    thumbnail: 'https://i.ytimg.com/vi/DAYNwC-aMgQ/hqdefault.jpg',
+    thumbnail: 'https://img.youtube.com/vi/DAYNwC-aMgQ/mqdefault.jpg',
     id: 'DAYNwC-aMgQ',
     embed: '<iframe width="100%" height="400" src="//www.youtube.com/embed/DAYNwC-aMgQ?autoplay=1&start=128" frameborder="0" scrolling="no" allowfullscreen></iframe>'
   },
@@ -31,7 +31,7 @@ expect(embeds).toEqual(
     type: 'video',
     url: 'https://youtube.com/watch?v=waiCd_CVxdc',
     provider_name: 'YouTube',
-    thumbnail: 'https://i.ytimg.com/vi/waiCd_CVxdc/hqdefault.jpg',
+    thumbnail: 'https://img.youtube.com/vi/waiCd_CVxdc/mqdefault.jpg',
     id: 'waiCd_CVxdc',
     embed: '<iframe width="100%" height="400" src="//www.youtube.com/embed/waiCd_CVxdc?autoplay=1" frameborder="0" scrolling="no" allowfullscreen></iframe>'
   }]


### PR DESCRIPTION
Partly fix to https://github.com/busyorg/busy/issues/1749.

### Before
---

<img width="543" alt="screen shot 2018-04-22 at 12 01 58 am" src="https://user-images.githubusercontent.com/72460/39088758-8e69338a-45c0-11e8-9210-c7c16a697812.png">

### After
---
<img width="536" alt="screen shot 2018-04-22 at 12 01 48 am" src="https://user-images.githubusercontent.com/72460/39088760-9aaff0c0-45c0-11e8-8557-f45d87e45940.png">

